### PR TITLE
Fix version number for opencv-python

### DIFF
--- a/third_party/gym-0.21.0/requirements.txt
+++ b/third_party/gym-0.21.0/requirements.txt
@@ -1,5 +1,5 @@
 ale-py~=0.7
-opencv-python>=3.
+opencv-python>=3.4.0
 box2d-py==2.3.5
 mujoco_py>=1.50, <2.0
 scipy>=1.4.1

--- a/third_party/gym-0.21.0/setup.py
+++ b/third_party/gym-0.21.0/setup.py
@@ -17,7 +17,7 @@ extras = {
     "mujoco": ["mujoco_py>=1.50, <2.0"],
     "robotics": ["mujoco_py>=1.50, <2.0"],
     "toy_text": ["scipy>=1.4.1"],
-    "other": ["lz4>=3.1.0", "opencv-python>=3."],
+    "other": ["lz4>=3.1.0", "opencv-python>=3.4.0"],
 }
 
 # Meta dependency groups.


### PR DESCRIPTION
The version number for opencv-python under gym-0.21.0 is "opencv-python>=3." in both requirements.txt and setup.py, leading to failure of installation. Changed to "opencv-python>=3.4.0" and works well. 